### PR TITLE
イベントデータ取得方法を修正 #30

### DIFF
--- a/app/controllers/api/v1/private_controller.rb
+++ b/app/controllers/api/v1/private_controller.rb
@@ -23,58 +23,23 @@ class Api::V1::PrivateController < ApplicationController
   # ユーザの全プライベートイベントを取得
   def get_all
     all_data = Private.where(user_id: @auth_user_id)
-    grouping_events_private(all_data)
-  end
-
-  # 全プライベートイベントをグルーピング
-  def grouping_events_private(all_data)
     begin
-      events = {}
-      totals = {}
-      graphs = {}
-
+      events = []
       all_data.each do |data|
         format_date = Time.zone.parse(data.date)
-
         event = {
           "id" => data.id,
           "amount" => data.amount,
           "category" => data.category,
-          "store_name" => data.store_name,
-          "data" => data.date,
-          "created_at" => data.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-          "updated_at" => data.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
+          "store" => data.store_name,
+          "date" => format_date.strftime("%Y-%m-%d"),
         }
-
-        # イベントを格納
-        if events.key?(format_date.strftime("%Y-%m-%d"))
-          events[format_date.strftime("%Y-%m-%d")].push(event)
-        else
-          events[format_date.strftime("%Y-%m-%d")] = [event]
-        end
-
-        # 月ごとの合計
-        if totals.key?(format_date.strftime("%Y-%m"))
-          totals[format_date.strftime("%Y-%m")] += data.amount
-        else
-          totals[format_date.strftime("%Y-%m")] = data.amount
-        end
-
-        # グラフ用データ
-        if graphs.key?(format_date.strftime("%Y-%m"))
-          graphs[format_date.strftime("%Y-%m")][
-            data.category
-          ] += data.amount
-        else
-          graph = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-          graph[data.category] = data.amount
-          graphs[format_date.strftime("%Y-%m")] = graph
-        end
+        events.push(event)
       end
-      render json: { "event" => events, "total" => totals, "graph" => graphs }, status: :ok
+      render json: { "events" => events }, status: :ok
     rescue => e
       render json: {
-               message: "Private Event grouping failed",
+               message: "Private All Event get to failed",
                errors: e,
              },
              status: :internal_server_error


### PR DESCRIPTION
- フロント側でローカルDBを使うため、DBから取得したデータをそのままフロント側に渡す
  - グルーピング処理を削除

issue:  フロント側でイベントデータを管理する #30 