### PR TITLE
リビジョン管理機能を実装

### DIFF
--- a/app/controllers/api/v1/event_controller.rb
+++ b/app/controllers/api/v1/event_controller.rb
@@ -227,4 +227,15 @@ class Api::V1::EventController < ApplicationController
              status: :unprocessable_entity
     end
   end
+
+  # 現在のリビジョンを取得
+  def revision
+    begin
+      user = User.find(@auth_user_id)
+      group = Group.find(user.group_id)
+      render json: { revision: group.revision }, status: :ok
+    rescue => e
+      render json: { message: "Failed to get revision", errors: e }, status: :internal_server_error
+    end
+  end
 end

--- a/app/controllers/api/v1/private_controller.rb
+++ b/app/controllers/api/v1/private_controller.rb
@@ -4,13 +4,17 @@ class Api::V1::PrivateController < ApplicationController
   def update
     begin
       event = Private.find(params[:id])
-      event.update(
-        amount: params[:amount],
-        category: params[:category],
-        store_name: params[:store_name],
-        date: params[:date],
-      )
-      render json: { message: "Private Event updated successfully" }, status: :ok
+      if @auth_user_id != event.user_id
+        render json: { message: "forbidden" }, status: :forbidden
+      else
+        event.update(
+          amount: params[:amount],
+          category: params[:category],
+          store_name: params[:store_name],
+          date: params[:date],
+        )
+        render json: { message: "Private Event updated successfully" }, status: :ok
+      end
     rescue => e
       render json: {
                message: "Private Event update failed",
@@ -50,16 +54,19 @@ class Api::V1::PrivateController < ApplicationController
   def get_one
     begin
       data = Private.find(params[:id])
-
-      result = {
-        "amount" => data.amount,
-        "category" => data.category,
-        "store_name" => data.store_name,
-        "date" => data.date,
-        "created_at" => data.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-        "updated_at" => data.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
-      }
-      render json: result, status: :ok
+      if @auth_user_id != data.user_id
+        render json: { message: "forbidden" }, status: :forbidden
+      else
+        result = {
+          "amount" => data.amount,
+          "category" => data.category,
+          "store_name" => data.store_name,
+          "date" => data.date,
+          "created_at" => data.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+          "updated_at" => data.updated_at.strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        render json: result, status: :ok
+      end
     rescue => e
       render json: {
                message: "Private Event get failed",
@@ -72,8 +79,13 @@ class Api::V1::PrivateController < ApplicationController
   # 指定したイベントを削除
   def delete
     begin
-      Private.find(params[:id]).destroy
-      render json: { message: "Private Event delete success" }, status: :ok
+      event = Private.find(params[:id])
+      if @auth_user_id != event.user_id
+        render json: { message: "forbidden" }, status: :forbidden
+      else
+        event.destroy
+        render json: { message: "Private Event delete success" }, status: :ok
+      end
     rescue => e
       render json: {
                message: "Private Event delete failed",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       get "/event", to: "event#get_all"
       get "/event/:id", to: "event#get_one"
       delete "/event/:id", to: "event#delete"
+      get "/revision", to: "event#revision"
 
       # プライベートイベント
       put "/private/:id", to: "private#update"

--- a/db/migrate/20230825132922_create_groups.rb
+++ b/db/migrate/20230825132922_create_groups.rb
@@ -2,6 +2,7 @@ class CreateGroups < ActiveRecord::Migration[7.0]
   def change
     create_table :groups do |t|
       t.string :manage_user
+      t.integer :revision, :default => 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2023_09_21_035624) do
-  create_table "events", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "events", charset: "utf8mb4", force: :cascade do |t|
     t.integer "amount", null: false
     t.integer "category"
     t.string "date"
@@ -23,13 +23,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_21_035624) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "groups", charset: "utf8mb4", force: :cascade do |t|
     t.string "manage_user"
+    t.integer "revision", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "privates", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "privates", charset: "utf8mb4", force: :cascade do |t|
     t.integer "amount", null: false
     t.integer "category"
     t.string "date"
@@ -39,7 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_21_035624) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest"
     t.integer "group_id", null: false


### PR DESCRIPTION
- グループテーブルにリビジョンカラムを追加
- イベントの新規登録・更新・削除したタイミングで、リビジョンをカウントアップする
- リビジョンを取得するエンドポイントを追加

issue:  共有家計簿で自分以外が更新した場合の処理 #34 